### PR TITLE
Replaced live() method due to it being deprecated in jQuery 1.7+

### DIFF
--- a/jquery.contenteditable.js
+++ b/jquery.contenteditable.js
@@ -33,12 +33,12 @@
 			// setting the key based on an attribute available on the same level as 'contentEditable'
 			var key = $this.attr("data-key");
 			// add triggers
-			$this.live('focus', function() {
+			$this.on('focus', function() {
 				var $this = $(this);
 				$this.data('enter', $this.html());
 				$this.data('before', $this.html());
 				return $this;
-			}).live('keyup paste', function() {
+			}).on('keyup paste', function() {
 				var $this = $(this);
 				var text = $this.html();
 				if ($this.data('before') !== text) {
@@ -48,7 +48,7 @@
 					parent.trigger({type: 'change', action : 'update', changed: data});
 				}
 				return $this;
-			}).live('blur', function() {
+			}).on('blur', function() {
 				var $this = $(this);
 				var text = $this.html();
 				if ($this.data('enter') !== text) {


### PR DESCRIPTION
According to jQuery's docs the live() method is deprecated for jQuery
versions 1.7+ Since I'm using 1.9.1 I needed to change this, otherwise
I would get errors.

See also: http://api.jquery.com/live/

ps: Thanks for sharing your work :)
