### PR TITLE
Use greater than or equal to a version for jquery dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,8 @@
+{
+	"name": "jquery-contenteditable",
+	"version": "0.2.0",
+	"main": ["./jquery.contenteditable.js"],
+	"dependencies": {
+		"jquery": ">=1.7.2"
+	}
+}

--- a/component.json
+++ b/component.json
@@ -3,6 +3,6 @@
 	"version": "0.2.0",
 	"main": ["./jquery.contenteditable.js"],
 	"dependencies": {
-		"jquery": "~2.0.3"
+		"jquery": ">=1.7.2"
 	}
 }


### PR DESCRIPTION
Also add another bower.json file, for bower > 0.9.0 uses `bower.json` instead of `component.json`.
